### PR TITLE
fix: cannot install MCP Servers when running "SuperGemini install".

### DIFF
--- a/Docs/Reference/diagnostic-reference.md
+++ b/Docs/Reference/diagnostic-reference.md
@@ -580,7 +580,7 @@ def time_operation(command, description):
     """Time a shell command and return duration"""
     start_time = time.time()
     try:
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(command, shell=(sys.platform == "win32"), capture_output=True, text=True, timeout=30)
         end_time = time.time()
         duration = end_time - start_time
         success = result.returncode == 0

--- a/setup/components/mcp.py
+++ b/setup/components/mcp.py
@@ -340,7 +340,7 @@ class MCPComponent(Component):
                 capture_output=True,
                 text=True,
                 timeout=180,
-                shell=True
+                shell=(sys.platform == "win32")
             )
             
             if result.returncode == 0:
@@ -373,7 +373,7 @@ class MCPComponent(Component):
                 capture_output=True,
                 text=True,
                 timeout=300,
-                shell=True
+                shell=(sys.platform == "win32")
             )
             
             if result.returncode == 0:
@@ -411,7 +411,7 @@ class MCPComponent(Component):
                 capture_output=True,
                 text=True,
                 timeout=30,
-                shell=True
+                shell=(sys.platform == "win32")
             )
             
             if result.returncode == 0:
@@ -434,7 +434,7 @@ class MCPComponent(Component):
                 capture_output=True,
                 text=True,
                 timeout=30,
-                shell=True
+                shell=(sys.platform == "win32")
             )
             
             if result.returncode == 0 and ("serena" in result.stdout or "serena-agent" in result.stdout):
@@ -454,7 +454,7 @@ class MCPComponent(Component):
         
         # Check Node.js version (>=18 required for MCP)
         try:
-            result = subprocess.run(["node", "--version"], capture_output=True, text=True, timeout=10, shell=True)
+            result = subprocess.run(["node", "--version"], capture_output=True, text=True, timeout=10, shell=(sys.platform == "win32"))
             if result.returncode == 0:
                 version = result.stdout.strip().lstrip('v')
                 major_version = int(version.split('.')[0])
@@ -469,7 +469,7 @@ class MCPComponent(Component):
         
         # Check npm availability
         try:
-            result = subprocess.run(["npm", "--version"], capture_output=True, text=True, timeout=10, shell=True)
+            result = subprocess.run(["npm", "--version"], capture_output=True, text=True, timeout=10, shell=(sys.platform == "win32"))
             if result.returncode != 0:
                 errors.append("npm not working properly")
             else:
@@ -479,7 +479,7 @@ class MCPComponent(Component):
         
         # Check uv availability (for Python-based MCP servers like Serena)
         try:
-            result = subprocess.run(["uv", "--version"], capture_output=True, text=True, timeout=10, shell=True)
+            result = subprocess.run(["uv", "--version"], capture_output=True, text=True, timeout=10, shell=(sys.platform == "win32"))
             if result.returncode == 0:
                 self.logger.debug(f"uv {result.stdout.strip()} OK")
             else:


### PR DESCRIPTION
## Description
Fixes a bug where MCP servers fail to install when using the `SuperGemini install` command on Linux environments.
The `subprocess.run` calls, which are intended to check for `node`, `npm`, and `uv`, are returning an error, leading the installation script to fail prematurely. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Breaking change

## Testing
- [x] Tests pass locally
- [x] Installation tested : `SuperGemini install --yes`
- [x] Documentation updated
- [ ] Examples verified

## Checklist
- [x] Code follows project standards
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated
